### PR TITLE
Add missing prev_shmem_request_hook() call

### DIFF
--- a/plprofiler.c
+++ b/plprofiler.c
@@ -632,6 +632,9 @@ init_hash_tables(void)
 static void
 profiler_shmem_request(void)
 {
+	if (prev_shmem_request_hook)
+		prev_shmem_request_hook();
+
 	RequestAddinShmemSpace(profiler_shmem_size());
 	RequestNamedLWLockTranche("plprofiler", 1);
 }


### PR DESCRIPTION
prev_shmem_request_hook was missing inside
profiler_shmem_request_hook (this hook was added for PG15 compatibility)