### PR TITLE
Adjustments for PostgreSQL 17

### DIFF
--- a/plprofiler.c
+++ b/plprofiler.c
@@ -1321,9 +1321,6 @@ pl_profiler_linestats_local(PG_FUNCTION_ARGS)
 		}
 	}
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
-
 	PG_RETURN_VOID();
 }
 
@@ -1418,9 +1415,6 @@ pl_profiler_linestats_shared(PG_FUNCTION_ARGS)
 	/* Release the shared lock on the shared memory data. */
 	LWLockRelease(plpss->lock);
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
-
 	PG_RETURN_VOID();
 }
 
@@ -1499,9 +1493,6 @@ pl_profiler_callgraph_local(PG_FUNCTION_ARGS)
 			tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 		}
 	}
-
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
 
 	PG_RETURN_VOID();
 }
@@ -1600,9 +1591,6 @@ pl_profiler_callgraph_shared(PG_FUNCTION_ARGS)
 
 	/* Release the shared lock on the shared memory data. */
 	LWLockRelease(plpss->lock);
-
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
 
 	PG_RETURN_VOID();
 }
@@ -1835,9 +1823,6 @@ pl_profiler_funcs_source(PG_FUNCTION_ARGS)
 		ReleaseSysCache(procTuple);
 		pfree(procSrc);
 	}
-
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
In (the upcoming) PG 17, the tuplestore_donestoring macro was removed in 75680c3 [0].

This commit removes all references to tuplestore_donestoring so that plprofiler can build with PG 17.

This macro has been a no-op since dd04e95 in 2003, so its non-breaking for all currently supported PG versions [1].

[0] https://github.com/postgres/postgres/commit/75680c3

[1] https://github.com/postgres/postgres/commit/dd04e95

(addendum to the commit message - 
Judging by the commit history of this project like [here](https://github.com/bigsql/plprofiler/commit/e15bca2a48d3ef31aee4911ee0342d36e981df47), super old PG version compatibility is not a concern.
