### PR TITLE
Convert plprofiler to use psycopg3 (psycopg) instead of psycopg2

### DIFF
--- a/python-plprofiler/plprofiler/plprofiler_tool.py
+++ b/python-plprofiler/plprofiler/plprofiler_tool.py
@@ -955,7 +955,7 @@ def edit_config_info(config):
         tmp_config.remove_section(s)
 
     tf = open(tf_name, 'r')
-    tmp_config.readfp(tf)
+    tmp_config.read_file(tf)
     tf.close()
     os.remove(tf_name)
 


### PR DESCRIPTION
Update plprofiler to utilize psycopg3, now imported as 'psycopg', replacing the deprecated psycopg2 module. Adjust imports, connections, and exceptions to align with the psycopg3 API.

Update SQL execution for setting search_path to use psycopg.sql. This change is necessary because psycopg3 does not support the previous parameterized format used with psycopg2.

In plprofiler_tool.py, replace the deprecated 'readfp' method with 'read_file' from ConfigParser to eliminate deprecation warnings and ensure compatibility with Python 3.