### PR TITLE
Fix build against PostgreSQL 19

### DIFF
--- a/plprofiler.c
+++ b/plprofiler.c
@@ -682,7 +682,6 @@ profiler_shmem_startup(void)
 	hash_ctl.match = line_match_fn;
 	functions_shared = ShmemInitHash("plprofiler functions",
 									 profiler_max_functions,
-									 profiler_max_functions,
 									 &hash_ctl,
 									 HASH_ELEM | HASH_FUNCTION | HASH_COMPARE);
 
@@ -693,7 +692,6 @@ profiler_shmem_startup(void)
 	hash_ctl.hash = callgraph_hash_fn;
 	hash_ctl.match = callgraph_match_fn;
 	callgraph_shared = ShmemInitHash("plprofiler callgraph",
-									  profiler_max_callgraph,
 									  profiler_max_callgraph,
 									  &hash_ctl,
 									  HASH_ELEM | HASH_FUNCTION | HASH_COMPARE);

--- a/plprofiler.h
+++ b/plprofiler.h
@@ -40,6 +40,8 @@
 #include "pgstat.h"
 #include "plpgsql.h"
 #include "storage/ipc.h"
+#include "storage/lwlock.h"
+#include "storage/shmem.h"
 #include "storage/spin.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
@@ -49,6 +51,7 @@
 #include "utils/memutils.h"
 #include "utils/palloc.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
 
 PG_MODULE_MAGIC;
 
@@ -161,7 +164,7 @@ typedef struct callGraphEntry
 
 typedef struct
 {
-	LWLockId			lock;
+	LWLock			   *lock;
 	bool				profiler_enabled_global;
 	int					profiler_enabled_pid;
 	int					profiler_collect_interval;


### PR DESCRIPTION
  plprofiler.h:
  * PG19's header include-what-you-use (IWYU) cleanup means <storage/lwlock.h>, <storage/shmem.h> and <utils/tuplestore.h> are no longer pulled in transitively by the headers plprofiler.h already included. Without them, LWLockAcquire/LWLockRelease, RequestAddinShmemSpace/RequestNamedLWLockTranche, ShmemInitStruct/ ShmemInitHash/GetNamedLWLockTranche and tuplestore_begin_heap/ tuplestore_putvalues were all implicitly declared, producing the "call to undeclared function" / "incompatible integer to pointer conversion" errors seen on both clang (LLVM bitcode build) and gcc. Add the three missing includes to plprofiler.h.
  * profilerSharedState.lock was declared as "LWLockId", a typedef that was removed from PostgreSQL back in 9.4 when LWLocks moved to a pointer-based API. The plprofiler code itself already treats plpss->lock as a pointer (e.g. "plpss->lock = &(GetNamedLWLockTranche(...))->lock;"), so the struct member had been silently relying on an implicit int-to- pointer conversion that recent compilers (and C99+) no longer allow. Change the member to the correct "LWLock *" type.

  plprofiler.c:
  * PG19 changed the signature of ShmemInitHash() from HTAB *ShmemInitHash(const char *name, long init_size, long max_size, HASHCTL *infoP, int hash_flags); to HTAB *ShmemInitHash(const char *name, int64 nelems, HASHCTL *infoP, int hash_flags); collapsing the separate init_size/max_size arguments into a single nelems argument. Both call sites in profiler_shmem_startup() (for the "plprofiler functions" and "plprofiler callgraph" shared hash tables) were passing the old 5-argument form, which now fails to compile ("too many arguments to function call" / argument-type mismatches). Drop the redundant init_size argument at both call sites so only one size argument (nelems) is passed.

Hacked by Claude, tested by me.

Per https://github.com/pgdg-packaging/pgdg-rpms/issues/213